### PR TITLE
Run autoloading separately from composer install

### DIFF
--- a/build.go
+++ b/build.go
@@ -365,8 +365,8 @@ func runComposerInstall(
 		Args: append([]string{"dump-autoload", "--classmap-authoritative"}),
 		Dir:  context.WorkingDir,
 		Env: append(os.Environ(),
-			"COMPOSER_NO_INTERACTION=1",  // https://getcomposer.org/doc/03-cli.md#composer-no-interaction
-			"COMPOSER_VENDOR_DIR=vendor", // ensure default in the layer
+			"COMPOSER_NO_INTERACTION=1", // https://getcomposer.org/doc/03-cli.md#composer-no-interaction
+			fmt.Sprintf("COMPOSER_VENDOR_DIR=%s", workspaceVendorDir),
 			fmt.Sprintf("PHPRC=%s", composerPhpIniPath),
 			fmt.Sprintf("PATH=%s", path),
 		),

--- a/determine_composer_install_options.go
+++ b/determine_composer_install_options.go
@@ -19,16 +19,19 @@ func (_ InstallOptions) Determine() []string {
 		return []string{
 			"--no-progress",
 			"--no-dev",
+			"--no-autoloader",
 		}
 	} else if installOptionsFromEnv == "" {
 		return []string{
 			"--no-progress",
+			"--no-autoloader",
 		}
 	} else {
 		parsedOptionsFromEnv, err := shellwords.Parse(installOptionsFromEnv)
 		if err != nil {
 			return []string{
 				"--no-progress",
+				"--no-autoloader",
 				installOptionsFromEnv,
 			}
 		}

--- a/determine_composer_install_options.go
+++ b/determine_composer_install_options.go
@@ -33,6 +33,6 @@ func (_ InstallOptions) Determine() []string {
 			}
 		}
 
-		return append([]string{"--no-progress"}, parsedOptionsFromEnv...)
+		return append([]string{"--no-progress", "--no-autoloader"}, parsedOptionsFromEnv...)
 	}
 }

--- a/determine_composer_install_options_test.go
+++ b/determine_composer_install_options_test.go
@@ -54,6 +54,7 @@ func testComposerInstallOptions(t *testing.T, context spec.G, it spec.S) {
 		it("should return those values as individual args", func() {
 			Expect(options.Determine()).To(Equal([]string{
 				"--no-progress",
+				"--no-autoloader",
 				"--foo=bar",
 				"-v",
 				"--something",

--- a/determine_composer_install_options_test.go
+++ b/determine_composer_install_options_test.go
@@ -30,6 +30,7 @@ func testComposerInstallOptions(t *testing.T, context spec.G, it spec.S) {
 			Expect(options.Determine()).To(Equal([]string{
 				"--no-progress",
 				"--no-dev",
+				"--no-autoloader",
 			}))
 		})
 	})
@@ -42,6 +43,7 @@ func testComposerInstallOptions(t *testing.T, context spec.G, it spec.S) {
 		it("should return --no-progress only", func() {
 			Expect(options.Determine()).To(Equal([]string{
 				"--no-progress",
+				"--no-autoloader",
 			}))
 		})
 	})
@@ -70,6 +72,7 @@ func testComposerInstallOptions(t *testing.T, context spec.G, it spec.S) {
 		it("should return those values as one single arg", func() {
 			Expect(options.Determine()).To(Equal([]string{
 				"--no-progress",
+				"--no-autoloader",
 				"invalid'option for composer",
 			}))
 		})

--- a/integration/default_app_test.go
+++ b/integration/default_app_test.go
@@ -65,7 +65,7 @@ func testDefaultApp(t *testing.T, context spec.G, it spec.S) {
 				Execute(name, source)
 			Expect(err).ToNot(HaveOccurred(), logs.String)
 
-			Expect(logs).To(ContainSubstring("Ran 'composer install --no-progress --no-dev'"))
+			Expect(logs).To(ContainSubstring("Ran 'composer install --no-progress --no-dev --no-autoloader'"))
 
 			Expect(logs).To(ContainLines(ContainSubstring("PHP Distribution Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Composer Buildpack")))

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -106,11 +106,12 @@ func TestIntegration(t *testing.T) {
 	SetDefaultEventuallyTimeout(5 * time.Second)
 
 	suite := spec.New("Integration", spec.Report(report.Terminal{}))
+	suite("CustomVendorDir", testCustomVendorDir)
 	suite("Default", testDefaultApp)
 	suite("Global", testGlobal)
-	suite("CustomVendorDir", testCustomVendorDir)
+	suite("ReusingLayerRebuild", testReusingLayerRebuild, spec.Sequential())
+	suite("TestOutsideAutoloading", testOutsideAutoloading)
 	suite("WithExtensions", testWithExtensions)
 	suite("WithVendoredPackages", testWithVendoredPackages)
-	suite("ReusingLayerRebuild", testReusingLayerRebuild, spec.Sequential())
 	suite.Run(t)
 }

--- a/integration/outside_autoloading_test.go
+++ b/integration/outside_autoloading_test.go
@@ -1,0 +1,88 @@
+package integration_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/paketo-buildpacks/occam"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/occam/matchers"
+)
+
+func testOutsideAutoloading(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect     = NewWithT(t).Expect
+		Eventually = NewWithT(t).Eventually
+
+		pack   occam.Pack
+		docker occam.Docker
+	)
+
+	it.Before(func() {
+		pack = occam.NewPack().WithVerbose().WithNoColor()
+		docker = occam.NewDocker()
+	})
+
+	context("building an app with classes to autoload outside of the vendor directory", func() {
+		var (
+			image     occam.Image
+			container occam.Container
+
+			name   string
+			source string
+		)
+
+		it.Before(func() {
+			var err error
+			name, err = occam.RandomName()
+			Expect(err).NotTo(HaveOccurred())
+			source, err = occam.Source(filepath.Join("testdata", "outside_autoloading_app"))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		it.After(func() {
+			Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
+			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
+			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+			Expect(os.RemoveAll(source)).To(Succeed())
+		})
+
+		it("builds and runs", func() {
+			var err error
+			var logs fmt.Stringer
+
+			image, logs, err = pack.Build.
+				WithPullPolicy("never").
+				WithBuildpacks(buildpacksArray...).
+				WithEnv(map[string]string{
+					"BP_PHP_SERVER":               "nginx",
+					"BP_COMPOSER_INSTALL_OPTIONS": "--no-scripts",
+				}).
+				Execute(name, source)
+			Expect(err).ToNot(HaveOccurred(), logs.String)
+
+			Expect(logs).To(ContainSubstring("Ran 'composer install --no-progress --no-autoloader --no-scripts'"))
+			Expect(logs).To(ContainSubstring("Ran 'composer dump-autoload --classmap-authoritative'"))
+
+			Expect(logs).To(ContainLines(ContainSubstring("PHP Distribution Buildpack")))
+			Expect(logs).To(ContainLines(ContainSubstring("Composer Buildpack")))
+			Expect(logs).To(ContainLines(ContainSubstring("Composer Install Buildpack")))
+			Expect(logs).To(ContainLines(ContainSubstring("PHP FPM Buildpack")))
+			Expect(logs).To(ContainLines(ContainSubstring("Nginx Server Buildpack")))
+			Expect(logs).To(ContainLines(ContainSubstring("PHP Nginx Buildpack")))
+			Expect(logs).To(ContainLines(ContainSubstring("PHP Start Buildpack")))
+
+			container, err = docker.Container.Run.
+				WithEnv(map[string]string{"PORT": "8080"}).
+				WithPublish("8080").
+				Execute(image.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(container).Should(Serve(ContainSubstring("ClassMap exists")).OnPort(8080))
+		})
+	})
+}

--- a/integration/outside_autoloading_test.go
+++ b/integration/outside_autoloading_test.go
@@ -59,13 +59,12 @@ func testOutsideAutoloading(t *testing.T, context spec.G, it spec.S) {
 				WithPullPolicy("never").
 				WithBuildpacks(buildpacksArray...).
 				WithEnv(map[string]string{
-					"BP_PHP_SERVER":               "nginx",
-					"BP_COMPOSER_INSTALL_OPTIONS": "--no-scripts",
+					"BP_PHP_SERVER": "nginx",
 				}).
 				Execute(name, source)
 			Expect(err).ToNot(HaveOccurred(), logs.String)
 
-			Expect(logs).To(ContainSubstring("Ran 'composer install --no-progress --no-autoloader --no-scripts'"))
+			Expect(logs).To(ContainSubstring("Ran 'composer install --no-progress --no-dev --no-autoloader'"))
 			Expect(logs).To(ContainSubstring("Ran 'composer dump-autoload --classmap-authoritative'"))
 
 			Expect(logs).To(ContainLines(ContainSubstring("PHP Distribution Buildpack")))
@@ -82,7 +81,10 @@ func testOutsideAutoloading(t *testing.T, context spec.G, it spec.S) {
 				Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(container).Should(Serve(ContainSubstring("ClassMap exists")).OnPort(8080))
+			Eventually(container).Should(Serve(And(
+				ContainSubstring("ClassMap exists"),
+				ContainSubstring("NonVendorClass exists"),
+			)).OnPort(8080))
 		})
 	})
 }

--- a/integration/testdata/outside_autoloading_app/README.md
+++ b/integration/testdata/outside_autoloading_app/README.md
@@ -1,0 +1,3 @@
+This app is based off of https://github.com/iainfogg/paketo-composer-demo to
+demonstrate the ability of the buildpack to autoload classes outside of the
+vendor directory.

--- a/integration/testdata/outside_autoloading_app/classmap/ClassMap.php
+++ b/integration/testdata/outside_autoloading_app/classmap/ClassMap.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+class ClassMap
+{
+
+}

--- a/integration/testdata/outside_autoloading_app/composer.json
+++ b/integration/testdata/outside_autoloading_app/composer.json
@@ -1,0 +1,13 @@
+{
+    "require": {
+        "vlucas/phpdotenv": "5.3.0",
+        "php": "8.*"
+    },
+    "autoload" :
+    {
+        "classmap" :
+        [
+            "classmap/ClassMap.php"
+        ]
+    }
+}

--- a/integration/testdata/outside_autoloading_app/composer.json
+++ b/integration/testdata/outside_autoloading_app/composer.json
@@ -5,6 +5,10 @@
     },
     "autoload" :
     {
+        "psr-4" :
+        {
+            "Application\\" : "src"
+        },
         "classmap" :
         [
             "classmap/ClassMap.php"

--- a/integration/testdata/outside_autoloading_app/composer.lock
+++ b/integration/testdata/outside_autoloading_app/composer.lock
@@ -8,24 +8,24 @@
     "packages": [
         {
             "name": "graham-campbell/result-type",
-            "version": "v1.0.4",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/GrahamCampbell/Result-Type.git",
-                "reference": "0690bde05318336c7221785f2a932467f98b64ca"
+                "reference": "a878d45c1914464426dc94da61c9e1d36ae262a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/0690bde05318336c7221785f2a932467f98b64ca",
-                "reference": "0690bde05318336c7221785f2a932467f98b64ca",
+                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/a878d45c1914464426dc94da61c9e1d36ae262a8",
+                "reference": "a878d45c1914464426dc94da61c9e1d36ae262a8",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0 || ^8.0",
-                "phpoption/phpoption": "^1.8"
+                "php": "^7.2.5 || ^8.0",
+                "phpoption/phpoption": "^1.9"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.5.14 || ^7.5.20 || ^8.5.19 || ^9.5.8"
+                "phpunit/phpunit": "^8.5.28 || ^9.5.21"
             },
             "type": "library",
             "autoload": {
@@ -54,7 +54,7 @@
             ],
             "support": {
                 "issues": "https://github.com/GrahamCampbell/Result-Type/issues",
-                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.0.4"
+                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.1.0"
             },
             "funding": [
                 {
@@ -66,33 +66,37 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-21T21:41:47+00:00"
+            "time": "2022-07-30T15:56:11+00:00"
         },
         {
             "name": "phpoption/phpoption",
-            "version": "1.8.1",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/php-option.git",
-                "reference": "eab7a0df01fe2344d172bff4cd6dbd3f8b84ad15"
+                "reference": "dc5ff11e274a90cc1c743f66c9ad700ce50db9ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/eab7a0df01fe2344d172bff4cd6dbd3f8b84ad15",
-                "reference": "eab7a0df01fe2344d172bff4cd6dbd3f8b84ad15",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/dc5ff11e274a90cc1c743f66c9ad700ce50db9ab",
+                "reference": "dc5ff11e274a90cc1c743f66c9ad700ce50db9ab",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0 || ^8.0"
+                "php": "^7.2.5 || ^8.0"
             },
             "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.4.1",
-                "phpunit/phpunit": "^6.5.14 || ^7.5.20 || ^8.5.19 || ^9.5.8"
+                "bamarni/composer-bin-plugin": "^1.8",
+                "phpunit/phpunit": "^8.5.28 || ^9.5.21"
             },
             "type": "library",
             "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": true
+                },
                 "branch-alias": {
-                    "dev-master": "1.8-dev"
+                    "dev-master": "1.9-dev"
                 }
             },
             "autoload": {
@@ -125,7 +129,7 @@
             ],
             "support": {
                 "issues": "https://github.com/schmittjoh/php-option/issues",
-                "source": "https://github.com/schmittjoh/php-option/tree/1.8.1"
+                "source": "https://github.com/schmittjoh/php-option/tree/1.9.0"
             },
             "funding": [
                 {
@@ -137,7 +141,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-04T23:24:31+00:00"
+            "time": "2022-07-30T15:51:26+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",

--- a/integration/testdata/outside_autoloading_app/composer.lock
+++ b/integration/testdata/outside_autoloading_app/composer.lock
@@ -1,0 +1,482 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "6b6ca6d9656676cd974f5b645bcab9be",
+    "packages": [
+        {
+            "name": "graham-campbell/result-type",
+            "version": "v1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/GrahamCampbell/Result-Type.git",
+                "reference": "0690bde05318336c7221785f2a932467f98b64ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/0690bde05318336c7221785f2a932467f98b64ca",
+                "reference": "0690bde05318336c7221785f2a932467f98b64ca",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "phpoption/phpoption": "^1.8"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.5.14 || ^7.5.20 || ^8.5.19 || ^9.5.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GrahamCampbell\\ResultType\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                }
+            ],
+            "description": "An Implementation Of The Result Type",
+            "keywords": [
+                "Graham Campbell",
+                "GrahamCampbell",
+                "Result Type",
+                "Result-Type",
+                "result"
+            ],
+            "support": {
+                "issues": "https://github.com/GrahamCampbell/Result-Type/issues",
+                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/graham-campbell/result-type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-11-21T21:41:47+00:00"
+        },
+        {
+            "name": "phpoption/phpoption",
+            "version": "1.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/schmittjoh/php-option.git",
+                "reference": "eab7a0df01fe2344d172bff4cd6dbd3f8b84ad15"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/eab7a0df01fe2344d172bff4cd6dbd3f8b84ad15",
+                "reference": "eab7a0df01fe2344d172bff4cd6dbd3f8b84ad15",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "phpunit/phpunit": "^6.5.14 || ^7.5.20 || ^8.5.19 || ^9.5.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpOption\\": "src/PhpOption/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Johannes M. Schmitt",
+                    "email": "schmittjoh@gmail.com",
+                    "homepage": "https://github.com/schmittjoh"
+                },
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                }
+            ],
+            "description": "Option Type for PHP",
+            "keywords": [
+                "language",
+                "option",
+                "php",
+                "type"
+            ],
+            "support": {
+                "issues": "https://github.com/schmittjoh/php-option/issues",
+                "source": "https://github.com/schmittjoh/php-option/tree/1.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpoption/phpoption",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-12-04T23:24:31+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.26.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4",
+                "reference": "6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.26-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.26.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-24T11:49:31+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.26.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e",
+                "reference": "9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.26-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.26.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-24T11:49:31+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.26.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "cfa0ae98841b9e461207c13ab093d76b0fa7bace"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/cfa0ae98841b9e461207c13ab093d76b0fa7bace",
+                "reference": "cfa0ae98841b9e461207c13ab093d76b0fa7bace",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.26-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.26.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-10T07:21:04+00:00"
+        },
+        {
+            "name": "vlucas/phpdotenv",
+            "version": "v5.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vlucas/phpdotenv.git",
+                "reference": "b3eac5c7ac896e52deab4a99068e3f4ab12d9e56"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/b3eac5c7ac896e52deab4a99068e3f4ab12d9e56",
+                "reference": "b3eac5c7ac896e52deab4a99068e3f4ab12d9e56",
+                "shasum": ""
+            },
+            "require": {
+                "ext-pcre": "*",
+                "graham-campbell/result-type": "^1.0.1",
+                "php": "^7.1.3 || ^8.0",
+                "phpoption/phpoption": "^1.7.4",
+                "symfony/polyfill-ctype": "^1.17",
+                "symfony/polyfill-mbstring": "^1.17",
+                "symfony/polyfill-php80": "^1.17"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "ext-filter": "*",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.14 || ^9.5.1"
+            },
+            "suggest": {
+                "ext-filter": "Required to use the boolean validator."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dotenv\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "graham@alt-three.com",
+                    "homepage": "https://gjcampbell.co.uk/"
+                },
+                {
+                    "name": "Vance Lucas",
+                    "email": "vance@vancelucas.com",
+                    "homepage": "https://vancelucas.com/"
+                }
+            ],
+            "description": "Loads environment variables from `.env` to `getenv()`, `$_ENV` and `$_SERVER` automagically.",
+            "keywords": [
+                "dotenv",
+                "env",
+                "environment"
+            ],
+            "support": {
+                "issues": "https://github.com/vlucas/phpdotenv/issues",
+                "source": "https://github.com/vlucas/phpdotenv/tree/v5.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/vlucas/phpdotenv",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-20T15:23:13+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "8.*"
+    },
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
+}

--- a/integration/testdata/outside_autoloading_app/htdocs/index.php
+++ b/integration/testdata/outside_autoloading_app/htdocs/index.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+if (class_exists('ClassMap')) {
+    echo "ClassMap exists";
+} else {
+    echo "Can't find ClassMap";
+}

--- a/integration/testdata/outside_autoloading_app/htdocs/index.php
+++ b/integration/testdata/outside_autoloading_app/htdocs/index.php
@@ -9,3 +9,11 @@ if (class_exists('ClassMap')) {
 } else {
     echo "Can't find ClassMap";
 }
+
+echo '<br>';
+
+if (class_exists('Application\\NonVendorClass')) {
+    echo "NonVendorClass exists";
+} else {
+    echo "Can't find NonVendorClass";
+}

--- a/integration/testdata/outside_autoloading_app/src/NonVendorClass.php
+++ b/integration/testdata/outside_autoloading_app/src/NonVendorClass.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application;
+
+class NonVendorClass
+{
+
+}

--- a/run/main.go
+++ b/run/main.go
@@ -24,6 +24,7 @@ func main() {
 	options := composer.NewComposerInstallOptions()
 
 	installExec := pexec.NewExecutable("composer")
+	dumpAutoloadExec := pexec.NewExecutable("composer")
 	globalExec := pexec.NewExecutable("composer")
 	checkPlatformReqsExec := pexec.NewExecutable("composer")
 
@@ -33,6 +34,7 @@ func main() {
 			logEmitter,
 			options,
 			installExec,
+			dumpAutoloadExec,
 			globalExec,
 			checkPlatformReqsExec,
 			Generator{},


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

#5 
Resolves failures to autoload classes outside of the vendor directory, caused by the `composer install` looking for classes inside of the layer, instead of the working directory. 

The solution is:
-  run `composer install` with the `--no-autoload` flag in ALL cases
- perform typical symlinking from the layer to the working directory, 
- and then run `composer dump-autoload` from the working directory to do the autoloading, where composer can find classes outside of vendor.
- added a test case/app like the sample given by OP to demonstrate that this bug has been resolved


## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
