### PR TITLE
Check and enable platform reqs before running `composer install`

### DIFF
--- a/build.go
+++ b/build.go
@@ -80,6 +80,11 @@ func Build(
 			workspaceVendorDir = filepath.Join(context.WorkingDir, value)
 		}
 
+		err = runCheckAndEnablePlatformReqs(logger, checkPlatformReqsExec, context.WorkingDir, composerPhpIniPath, path)
+		if err != nil {
+			return packit.BuildResult{}, err
+		}
+
 		var composerPackagesLayer packit.Layer
 		logger.Process("Executing build process")
 		duration, err := clock.Measure(func() error {
@@ -117,11 +122,6 @@ func Build(
 		logger.FormattingSBOM(context.BuildpackInfo.SBOMFormats...)
 
 		composerPackagesLayer.SBOM, err = sbomContent.InFormats(context.BuildpackInfo.SBOMFormats...)
-		if err != nil {
-			return packit.BuildResult{}, err
-		}
-
-		err = runCheckPlatformReqs(logger, checkPlatformReqsExec, context.WorkingDir, composerPhpIniPath, path)
 		if err != nil {
 			return packit.BuildResult{}, err
 		}
@@ -407,7 +407,7 @@ extension = openssl.so`, os.Getenv(PhpExtensionDir))
 	return composerPhpIniPath, os.WriteFile(composerPhpIniPath, []byte(phpIni), os.ModePerm)
 }
 
-// runCheckPlatformReqs will run Composer command `check-platform-reqs`
+// runCheckAndEnablePlatformReqs will run Composer command `check-platform-reqs`
 // to see which platform requirements are "missing".
 // https://getcomposer.org/doc/03-cli.md#check-platform-reqs
 //
@@ -421,7 +421,7 @@ extension = openssl.so`, os.Getenv(PhpExtensionDir))
 // https://github.com/paketo-buildpacks/php-composer/blob/5e2604b74cbeb30090bf7eadb1cfc158b374efc0/composer/composer.go#L76-L100
 //
 // In case you are curious about exit code 2: https://getcomposer.org/doc/03-cli.md#process-exit-codes
-func runCheckPlatformReqs(logger scribe.Emitter, checkPlatformReqsExec Executable, workingDir, composerPhpIniPath, path string) error {
+func runCheckAndEnablePlatformReqs(logger scribe.Emitter, checkPlatformReqsExec Executable, workingDir, composerPhpIniPath, path string) error {
 
 	args := []string{"check-platform-reqs"}
 	logger.Process("Running 'composer %s'", strings.Join(args, " "))

--- a/build_test.go
+++ b/build_test.go
@@ -29,11 +29,11 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		composerConfigExecutable                *fakes.Executable
 		composerInstallExecutable               *fakes.Executable
 		composerGlobalExecutable                *fakes.Executable
-		composerCheckPlatformReqsExecExecutable *fakes.Executable
+		composerCheckAndEnablePlatformReqsExecExecutable *fakes.Executable
 		composerConfigExecution                 pexec.Execution
 		composerInstallExecution                pexec.Execution
 		composerGlobalExecution                 pexec.Execution
-		composerCheckPlatformReqsExecExecution  pexec.Execution
+		composerCheckAndEnablePlatformReqsExecExecution  pexec.Execution
 		sbomGenerator                           *fakes.SBOMGenerator
 		calculator                              *fakes.Calculator
 
@@ -59,7 +59,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		composerConfigExecutable = &fakes.Executable{}
 		composerInstallExecutable = &fakes.Executable{}
 		composerGlobalExecutable = &fakes.Executable{}
-		composerCheckPlatformReqsExecExecutable = &fakes.Executable{}
+		composerCheckAndEnablePlatformReqsExecExecutable = &fakes.Executable{}
 
 		composerConfigExecutable.ExecuteCall.Stub = func(temp pexec.Execution) error {
 			Expect(fmt.Fprint(temp.Stdout, "stdout from composer config\n")).To(Equal(28))
@@ -84,8 +84,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			return nil
 		}
 
-		composerCheckPlatformReqsExecExecutable.ExecuteCall.Stub = func(temp pexec.Execution) error {
-			composerCheckPlatformReqsExecExecution = temp
+		composerCheckAndEnablePlatformReqsExecExecutable.ExecuteCall.Stub = func(temp pexec.Execution) error {
+			composerCheckAndEnablePlatformReqsExecExecution = temp
 
 			_, err := temp.Stdout.Write([]byte(`ext-hello  8.1.4    missing
 ext-foo   8.1.4    success
@@ -117,7 +117,7 @@ php       8.1.4    success
 			composerConfigExecutable,
 			composerInstallExecutable,
 			composerGlobalExecutable,
-			composerCheckPlatformReqsExecExecutable,
+			composerCheckAndEnablePlatformReqsExecExecutable,
 			sbomGenerator,
 			"fake-path-from-tests",
 			calculator,
@@ -539,11 +539,11 @@ composer-lock-sha = "sha-from-composer-lock"
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(composerCheckPlatformReqsExecExecution.Args[0]).To(Equal("check-platform-reqs"))
-			Expect(composerCheckPlatformReqsExecExecution.Dir).To(Equal(workingDir))
-			Expect(len(composerCheckPlatformReqsExecExecution.Env)).To(Equal(len(os.Environ()) + 3))
+			Expect(composerCheckAndEnablePlatformReqsExecExecution.Args[0]).To(Equal("check-platform-reqs"))
+			Expect(composerCheckAndEnablePlatformReqsExecExecution.Dir).To(Equal(workingDir))
+			Expect(len(composerCheckAndEnablePlatformReqsExecExecution.Env)).To(Equal(len(os.Environ()) + 3))
 
-			Expect(composerCheckPlatformReqsExecExecution.Env).To(ContainElements(
+			Expect(composerCheckAndEnablePlatformReqsExecExecution.Env).To(ContainElements(
 				"COMPOSER_NO_INTERACTION=1",
 				fmt.Sprintf("PHPRC=%s", filepath.Join(layersDir, "composer-php-ini", "composer-php.ini")),
 				"PATH=fake-path-from-tests"))
@@ -625,11 +625,11 @@ extension = bar.so
 			})
 		})
 
-		context("when composerCheckPlatformReqsExecution fails", func() {
+		context("when composerCheckAndEnablePlatformReqsExecution fails", func() {
 			it.Before(func() {
-				composerCheckPlatformReqsExecExecutable.ExecuteCall.Stub = func(temp pexec.Execution) error {
-					composerCheckPlatformReqsExecExecution = temp
-					_, _ = fmt.Fprint(composerCheckPlatformReqsExecExecution.Stderr, "error message from check-platform-reqs")
+				composerCheckAndEnablePlatformReqsExecExecutable.ExecuteCall.Stub = func(temp pexec.Execution) error {
+					composerCheckAndEnablePlatformReqsExecExecution = temp
+					_, _ = fmt.Fprint(composerCheckAndEnablePlatformReqsExecExecution.Stderr, "error message from check-platform-reqs")
 					return errors.New("some error from check-platform-reqs")
 				}
 			})

--- a/integration/testdata/with_extensions/composer.lock
+++ b/integration/testdata/with_extensions/composer.lock
@@ -4,28 +4,28 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1a729e202237407f0b46a456b667efa8",
+    "content-hash": "61414f3c4753a71190dbbced959383f3",
     "packages": [
         {
             "name": "graham-campbell/result-type",
-            "version": "v1.0.4",
+            "version": "v1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/GrahamCampbell/Result-Type.git",
-                "reference": "0690bde05318336c7221785f2a932467f98b64ca"
+                "reference": "fbd48bce38f73f8a4ec8583362e732e4095e5862"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/0690bde05318336c7221785f2a932467f98b64ca",
-                "reference": "0690bde05318336c7221785f2a932467f98b64ca",
+                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/fbd48bce38f73f8a4ec8583362e732e4095e5862",
+                "reference": "fbd48bce38f73f8a4ec8583362e732e4095e5862",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0 || ^8.0",
-                "phpoption/phpoption": "^1.8"
+                "php": "^7.2.5 || ^8.0",
+                "phpoption/phpoption": "^1.9.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.5.14 || ^7.5.20 || ^8.5.19 || ^9.5.8"
+                "phpunit/phpunit": "^8.5.34 || ^9.6.13 || ^10.4.2"
             },
             "type": "library",
             "autoload": {
@@ -54,7 +54,7 @@
             ],
             "support": {
                 "issues": "https://github.com/GrahamCampbell/Result-Type/issues",
-                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.0.4"
+                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.1.2"
             },
             "funding": [
                 {
@@ -66,33 +66,37 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-21T21:41:47+00:00"
+            "time": "2023-11-12T22:16:48+00:00"
         },
         {
             "name": "phpoption/phpoption",
-            "version": "1.8.1",
+            "version": "1.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/php-option.git",
-                "reference": "eab7a0df01fe2344d172bff4cd6dbd3f8b84ad15"
+                "reference": "80735db690fe4fc5c76dfa7f9b770634285fa820"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/eab7a0df01fe2344d172bff4cd6dbd3f8b84ad15",
-                "reference": "eab7a0df01fe2344d172bff4cd6dbd3f8b84ad15",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/80735db690fe4fc5c76dfa7f9b770634285fa820",
+                "reference": "80735db690fe4fc5c76dfa7f9b770634285fa820",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0 || ^8.0"
+                "php": "^7.2.5 || ^8.0"
             },
             "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.4.1",
-                "phpunit/phpunit": "^6.5.14 || ^7.5.20 || ^8.5.19 || ^9.5.8"
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.34 || ^9.6.13 || ^10.4.2"
             },
             "type": "library",
             "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": true
+                },
                 "branch-alias": {
-                    "dev-master": "1.8-dev"
+                    "dev-master": "1.9-dev"
                 }
             },
             "autoload": {
@@ -125,7 +129,7 @@
             ],
             "support": {
                 "issues": "https://github.com/schmittjoh/php-option/issues",
-                "source": "https://github.com/schmittjoh/php-option/tree/1.8.1"
+                "source": "https://github.com/schmittjoh/php-option/tree/1.9.2"
             },
             "funding": [
                 {
@@ -137,20 +141,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-04T23:24:31+00:00"
+            "time": "2023-11-12T21:59:55+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.25.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "30885182c981ab175d4d034db0f6f469898070ab"
+                "reference": "0424dff1c58f028c451efff2045f5d92410bd540"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/30885182c981ab175d4d034db0f6f469898070ab",
-                "reference": "30885182c981ab175d4d034db0f6f469898070ab",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/0424dff1c58f028c451efff2045f5d92410bd540",
+                "reference": "0424dff1c58f028c451efff2045f5d92410bd540",
                 "shasum": ""
             },
             "require": {
@@ -164,9 +168,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.23-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -203,7 +204,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.25.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -219,20 +220,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-10-20T20:35:02+00:00"
+            "time": "2024-05-31T15:07:36+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.25.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825"
+                "reference": "fd22ab50000ef01661e2a31d850ebaa297f8e03c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/0abb51d2f102e00a4eefcf46ba7fec406d245825",
-                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fd22ab50000ef01661e2a31d850ebaa297f8e03c",
+                "reference": "fd22ab50000ef01661e2a31d850ebaa297f8e03c",
                 "shasum": ""
             },
             "require": {
@@ -246,9 +247,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.23-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -286,7 +284,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.25.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -302,20 +300,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-30T18:21:41+00:00"
+            "time": "2024-06-19T12:30:46+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.25.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "4407588e0d3f1f52efb65fbe92babe41f37fe50c"
+                "reference": "77fa7995ac1b21ab60769b7323d600a991a90433"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/4407588e0d3f1f52efb65fbe92babe41f37fe50c",
-                "reference": "4407588e0d3f1f52efb65fbe92babe41f37fe50c",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/77fa7995ac1b21ab60769b7323d600a991a90433",
+                "reference": "77fa7995ac1b21ab60769b7323d600a991a90433",
                 "shasum": ""
             },
             "require": {
@@ -323,9 +321,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.23-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -369,7 +364,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.25.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -385,7 +380,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-04T08:16:47+00:00"
+            "time": "2024-05-31T15:07:36+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -475,8 +470,13 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "8.*"
+        "php": "8.*",
+        "ext-zip": "*",
+        "ext-gd": "*",
+        "ext-fileinfo": "*",
+        "ext-mysqli": "*",
+        "ext-mbstring": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## Summary

Resolve test failures related to `composer install` with Composer 2.7.7 by checking/enabling platform reqs before running `composer install`:
```
[builder]   Running 'composer install --no-progress --no-dev'
[builder]       Composer could not detect the root package (paketo/composer_app) version, defaulting to '1.0.0'. See https://getcomposer.org/root-version
[builder]       Installing dependencies from lock file
[builder]       Verifying lock file contents can be installed on current platform.
[builder]       Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. It is recommended that you run `composer update` or `composer update <package name>`.
[builder]       Your lock file does not contain a compatible set of packages. Please run composer update.
[builder]       
[builder]         Problem 1
[builder]           - Root composer.json requires PHP extension ext-zip * but it is missing from your system. Install or enable PHP's zip extension.
[builder]         Problem 2
[builder]           - Root composer.json requires PHP extension ext-gd * but it is missing from your system. Install or enable PHP's gd extension.
[builder]         Problem 3
[builder]           - Root composer.json requires PHP extension ext-fileinfo * but it is missing from your system. Install or enable PHP's fileinfo extension.
[builder]         Problem 4
[builder]           - Root composer.json requires PHP extension ext-mysqli * but it is missing from your system. Install or enable PHP's mysqli extension.
[builder]       
[builder]       To enable extensions, verify that they are enabled in your .ini files:
[builder]           - /layers/paketo-buildpacks_composer-install/composer-php-ini/composer-php.ini
[builder]           - /layers/paketo-buildpacks_php-dist/php/etc/buildpack.ini
[builder]           - /layers/paketo-buildpacks_php-dist/php/etc/php.ini
[builder]           - /layers/paketo-buildpacks_php-dist/php/etc/buildpack.ini
[builder]           - /layers/paketo-buildpacks_php-dist/php/etc/php.ini
[builder]       You can also run `php --ini` in a terminal to see which files are used by PHP in CLI mode.
[builder]       Alternatively, you can run Composer with `--ignore-platform-req=ext-zip --ignore-platform-req=ext-gd --ignore-platform-req=ext-fileinfo --ignore-platform-req=ext-mysqli` to temporarily ignore these required extensions.
[builder] exit status 2
[builder] ERROR: failed to build: exit status 1
ERROR: failed to build: executing lifecycle: failed with status code: 51
```
- We previously checked extensions, and made them available after `composer install` ran

- As of Composer 2.7.7, `composer install` includes a platform reqs check against the composer.json and composer.lock files. This check requires the extensions to be loaded/available to composer when the install command runs.

* testdata: update app composer.lock

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
